### PR TITLE
1.1.8

### DIFF
--- a/PSAzureMigrationAdvisor/PSAzureMigrationAdvisor.psd1
+++ b/PSAzureMigrationAdvisor/PSAzureMigrationAdvisor.psd1
@@ -3,7 +3,7 @@
 	RootModule = 'PSAzureMigrationAdvisor.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.1.5'
+	ModuleVersion = '1.1.8'
 	
 	# ID used to uniquely identify this module
 	GUID = 'f3cb2750-2108-4462-a86b-e542d12370c8'
@@ -27,7 +27,7 @@
 	# this module
 	RequiredModules = @(
 		@{ ModuleName='PSFramework'; ModuleVersion='1.6.214' }
-		@{ ModuleName='Refactor'; ModuleVersion='1.1.12' }
+		@{ ModuleName='Refactor'; ModuleVersion='1.1.15' }
 	)
 	
 	# Assemblies that must be loaded prior to importing this module
@@ -42,6 +42,7 @@
 	# Functions to export from this module
 	FunctionsToExport = @(
 		'Convert-AzScriptFile'
+		'Export-AzScriptReport'
 		'Read-AzScriptFile'
 	)
 	

--- a/PSAzureMigrationAdvisor/changelog.md
+++ b/PSAzureMigrationAdvisor/changelog.md
@@ -1,5 +1,11 @@
 ﻿# Changelog
 
+## 1.1.8 (2022-06-15)
+
++ New: Command Export-AzScriptReport - Provides improved reporting of results
++ Upd: Convert-AzScriptFile - added `-OutPath` parameter to support writing converted files to a different path, rather than overwriting the originals
++ Fix: Read-AzScriptFile - now accepts empty file-content.
+
 ## 1.1.5 (2022-04-14)
 
 + Upd: Read-AzScriptFile - added support to provide name and text content, instead of path to file

--- a/PSAzureMigrationAdvisor/en-us/strings.psd1
+++ b/PSAzureMigrationAdvisor/en-us/strings.psd1
@@ -1,12 +1,17 @@
 ﻿# This is where the strings go, that are written by
 # Write-PSFMessage, Stop-PSFFunction or the PSFramework validation scriptblocks
 @{
+	'Convert-AzScriptFile.Converting.Error'   = 'Error parsing file: {0}' # $filePath
 	'Convert-AzScriptFile.Converting'         = 'Applying {0} changes to file {1}' # $results.Count, $filePath
+	'Convert-AzScriptFile.ConvertingWriting'  = 'Applying {0} changes to file {1}, exporting changes to {2}' # $results.Count, $filePath, $resolvedOutPath
 	'Convert-AzScriptFile.Danger.Warning'     = 'This command is dangerous! Almost all converted commands require manual adjustments after renaming them. Use "Read-AzScriptFile" to do a read-only scan and obtain a list of files and locations before converting them. This command is only there to help with and accelerate the manual migration, it is fundamentally unable to guarantee a functional migration on its own. Best prepare a backup of your code before running this command!' # 
 	'Convert-AzScriptFile.Path.CommandsFound' = 'Found {0} applicable commands in {1}' # @($relevantTokens).Count, $filePath
 	'Convert-AzScriptFile.Path.NoAzCommand'   = 'No applicable commands found in "{0}", skipping file' # $filePath
 	'Convert-AzScriptFile.Path.NoScript'      = 'The specified file is not a recognized script file: {0}' # $filePath
 	'Convert-AzScriptFile.Path.ResolveError'  = 'Unable to resolve the specified path: {0}' # $pathName
+
+	'Export-AzScriptReport.NoExcel'           = 'The PowerShell module "ImportExcel" was not found on the computer, but is required to write .xslx files. Run "Install-Module ImportExcel -Scope CurrentUser" to install the module or change the extension to ".csv".' #
+	'Export-AzScriptReport.Export.Failed'     = 'Failed to start the export to {0}' # $Path
 
 	'Read-AzScriptFile.Path.CommandsFound'    = 'Found {0} applicable commands in {1}' # @($relevantTokens).Count, $filePath
 	'Read-AzScriptFile.Path.NoAzCommand'      = 'No applicable commands found in "{0}", skipping file' # $filePath

--- a/PSAzureMigrationAdvisor/functions/Export-AzScriptReport.ps1
+++ b/PSAzureMigrationAdvisor/functions/Export-AzScriptReport.ps1
@@ -1,0 +1,105 @@
+﻿function Export-AzScriptReport {
+	<#
+	.SYNOPSIS
+		Exports the results of Read-AzScriptFile to csv or xlsx.
+	
+	.DESCRIPTION
+		Exports the results of Read-AzScriptFile to csv or xlsx.
+		It reformats some of the data and eliminates linebreaks in the "Before" column.
+
+		In order to generate xlsx files, the additional module "ImportExcel" is required.
+	
+	.PARAMETER Path
+		The path where to write the report to.
+		May be a relative path, must include the filename.
+		The parent folder must already exist.
+	
+	.PARAMETER Delimiter
+		Which delimiter to use when generating a CSV file.
+		Defaults to the current culture, but may be overridden as needed.
+		This affects whether you can open the file in Excel by simple doubleclick or whether you need to first import the data.
+	
+	.PARAMETER InputObject
+		The report objects from Read-AzScriptFile to export.
+	
+	.EXAMPLE
+		PS C:\> Get-ChildItem C:\scripts -Recurse -Filter *.ps1 | Read-AzScriptFile | Export-AzScriptReport -Path .\report.csv
+		
+		Will search all PowerShell code under C:\scripts, search it for AzureAD and MSOnline commands and then export the finidngs to .\report.csv.
+	#>
+	[CmdletBinding()]
+	param (
+		[Parameter(Position = 0, Mandatory = $true)]
+		[PsfValidateScript('PSFramework.Validate.FSPath.FileOrParent', ErrorString = 'PSFramework.Validate.FSPath.FileOrParent')]
+		[string]
+		$Path,
+
+		[string]
+		$Delimiter = (Get-PSFConfigValue -FullName 'PSAzureMigrationAdvisor.Export.CsvDelimiter'),
+
+		[Parameter(ValueFromPipeline = $true)]
+		$InputObject
+	)
+
+	begin {
+		$useExcel = $Path -like "*.xlsx"
+		if ($useExcel -and -not (Get-Command Export-Excel -ErrorAction Ignore)) {
+			Stop-PSFFunction -String 'Export-AzScriptReport.NoExcel' -EnableException $true -Cmdlet $PSCmdlet
+		}
+
+		if ($useExcel) {
+			$steppable = { Export-Excel -Path $Path }.GetSteppablePipeline()
+		}
+		else {
+			$param = @{ Path = $Path }
+			if ($Delimiter) { $param.Delimiter = $Delimiter }
+			else { $param.UseCulture = $true }
+			$steppable = { Export-Csv @param }.GetSteppablePipeline()
+		}
+
+		try { $steppable.Begin($true) }
+		catch { Stop-PSFFunction -String 'Export-AzScriptReport.Export.Failed' -StringValues $Path -ErrorRecord $_ -EnableException $true -Cmdlet $PSCmdlet }
+	}
+	process {
+		foreach ($datum in $InputObject) {
+			#region Process Messages
+			# Note: This approach breaks down for messages that had multiple lines
+			$msgInfo = @()
+			$msgWarning = @()
+			$msgError = @()
+
+			$msgTypes = $datum.MessageType -split "`n"
+			$messages = $datum.Message -split "`n"
+
+			if ($msgTypes) {
+				foreach ($index in 0..$msgTypes.Count) {
+					switch (($msgTypes)[$index]) {
+						'Info' { $msgInfo += $messages[$index] }
+						'Information' { $msgInfo += $messages[$index] }
+						'Warning' { $msgWarning += $messages[$index] }
+						'Error' { $msgError += $messages[$index] }
+					}
+				}
+			}
+			#endregion Process Messages
+
+			$result = [PSCustomObject][ordered]@{
+				Path        = $datum.Path
+				Command     = $datum.Command
+				CommandLine = $datum.CommandLine
+				Before      = $datum.Before -replace "``[`r`n]+" -replace '\s+', ' ' # Eliminate backticks and linebreaks
+				After       = $datum.After
+				MsgInfo     = $msgInfo -join "  "
+				MsgWarning  = $msgWarning -join "  "
+				MsgError    = $msgError -join "  "
+				FileHash    = $datum.Filehash
+				MessageType = $datum.MessageType # Keep in the full dataset, just in case somebody includes multiline messages
+				Messages    = $datum.Message
+			}
+			$steppable.Process($result)
+		}
+	}
+	end {
+		$steppable.End()
+	}
+}

--- a/PSAzureMigrationAdvisor/functions/Read-AzScriptFile.ps1
+++ b/PSAzureMigrationAdvisor/functions/Read-AzScriptFile.ps1
@@ -68,6 +68,7 @@
 		$Name,
 
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Content')]
+		[AllowEmptyString()]
 		[string]
 		$Content,
 

--- a/PSAzureMigrationAdvisor/internal/configurations/configuration.ps1
+++ b/PSAzureMigrationAdvisor/internal/configurations/configuration.ps1
@@ -13,3 +13,5 @@ Set-PSFConfig -Module 'PSAzureMigrationAdvisor' -Name 'Example.Setting' -Value 1
 
 Set-PSFConfig -Module 'PSAzureMigrationAdvisor' -Name 'Import.DoDotSource' -Value $false -Initialize -Validation 'bool' -Description "Whether the module files should be dotsourced on import. By default, the files of this module are read as string value and invoked, which is faster but worse on debugging."
 Set-PSFConfig -Module 'PSAzureMigrationAdvisor' -Name 'Import.IndividualFiles' -Value $false -Initialize -Validation 'bool' -Description "Whether the module files should be imported individually. During the module build, all module code is compiled into few files, which are imported instead by default. Loading the compiled versions is faster, using the individual files is easier for debugging and testing out adjustments."
+
+Set-PSFConfig -Module 'PSAzureMigrationAdvisor' -Name 'Export.CsvDelimiter' -Value '' -Initialize -Validation 'string' -Description 'The delimiter to use with "Export-AzScriptReport" when generating CSV files. By default, the current culture will be used.'


### PR DESCRIPTION
+ New: Command Export-AzScriptReport - Provides improved reporting of results
+ Upd: Convert-AzScriptFile - added `-OutPath` parameter to support writing converted files to a different path, rather than overwriting the originals
+ Fix: Read-AzScriptFile - now accepts empty file-content.